### PR TITLE
Fix for Yahoo Finance throwing a 403 for no headers

### DIFF
--- a/FundamentalAnalysis/stock_data.py
+++ b/FundamentalAnalysis/stock_data.py
@@ -46,10 +46,16 @@ def stock_data(ticker, period="max", interval="1d", start=None, end=None):
         parameters["period1"] = start_timestamp
         parameters["period2"] = end_timestamp
 
-    url = f"https://query1.finance.yahoo.com/v8/finance/chart/{ticker}"
+    url = "https://query1.finance.yahoo.com/v8/finance/chart/{ticker}"
 
     try:
-        data = requests.get(url=url, params=parameters)
+        header = {'Connection': 'keep-alive',
+                  'Expires': '-1',
+                  'Upgrade-Insecure-Requests': '1',
+                  'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; WOW64) \
+                                     AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.99 Safari/537.36'
+                  }
+        data = requests.get(url=url, params=parameters, headers=header)
         data_json = data.json()['chart']['result'][0]
     except TypeError:
         raise TypeError("No data available. Please check if you have a valid period and/or interval. \n"


### PR DESCRIPTION
Yahoo Finance now throws a 403 forbidden exception for requests without headers. This PR is to fix this issue. Please see screenshot for proof of error and correctness

Before fix:
https://imgur.com/VGGvqJr

After fix:
https://imgur.com/tMw20AX