### PR TITLE
Small bugfix in the example code on README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ stock_data = fa.stock_data(ticker, period="ytd", interval="1d")
 stock_data_detailed = fa.stock_data_detailed(ticker, api_key, begin="2000-01-01", end="2020-01-01")
 
 # Download dividend history
-dividends = stock_dividend(ticker, api_key, begin="2000-01-01", end="2020-01-01")
+dividends = fa.stock_dividend(ticker, api_key, begin="2000-01-01", end="2020-01-01")
 
 ```
 


### PR DESCRIPTION
Last line of the example code in README.md had a small bug. Instead of instead of fa.dividends(..) it was just dividends(), so it was giving error that dividend function is not defined when I was trying to run the code.